### PR TITLE
Fix: Correct typo in ApplicationOrchestrator for overrideQrCode variable

### DIFF
--- a/WindowsFormsApp1/ApplicationOrchestrator.cs
+++ b/WindowsFormsApp1/ApplicationOrchestrator.cs
@@ -186,7 +186,7 @@ namespace WindowsFormsApp1
                 if (tpl != null)
                 {
                     string traceabilityCode = TraceabilityCodeGenerator.GenerateTraceabilityCode();
-                    string qrCodeToUse = overrideQrCode ?? tpl.qrcode;
+                    string qrCodeToUse = qrOverride ?? tpl.qrcode;
 
                     PrintJobData jobData = new PrintJobData
                     {


### PR DESCRIPTION
Resolved compile error CS0103 in ApplicationOrchestrator.cs. The variable `qrOverride` was incorrectly typed as `overrideQrCode` in the `ProcessMessageWithLegacyMethodAsync` method when determining the QR code to use for printing. This change corrects the variable name to match its declaration.